### PR TITLE
feat: only show `stale` field for repos that use the label

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             <span id="prs-count">PRs: 0</span>
             <span id="issues-count">Issues: 0</span>
             <span id="open-issues-count">Open: 0</span>
-            <span id="stale-count" style="color: #AFA7F3;">Stale: 0</span>
+            <span id="stale-count">Stale: 0</span>
         </span>
         <span id="button-group">
             <button id="fetch-issue"><span class="dice">🎲</span></button>

--- a/script.ts
+++ b/script.ts
@@ -59,6 +59,18 @@ function updateStatusFields(issues: GitHubIssue[]) {
     issuesCount.textContent = `Issues: ${allIssues}`;
     openIssuesCount.textContent = `Open: ${openIssues}`;
     staleCount.textContent = `Stale: ${staleIssues}`;
+    if (staleIssues > 0) {
+        const firstStaleIssueColor = issues.find(issue => 
+            !issue.pull_request &&
+            issue.labels.some(label => label.name.toLowerCase() === 'stale')
+        )?.labels.find(label => label.name.toLowerCase() === 'stale')?.color;
+        if (firstStaleIssueColor) {
+            staleCount.style.color = `#${firstStaleIssueColor}`;
+        }
+        staleCount.style.display = 'block';
+    } else {
+        staleCount.style.display = 'none';
+    }
 }
 
 function appendOutput(title: string, issueNumber?: number, url?: string, debug?: boolean) {

--- a/style.css
+++ b/style.css
@@ -109,6 +109,10 @@ datalist option:hover {
     background-color: #f8f8f8;
 }
 
+#stale-count {
+    display: none;
+}
+
 /* 4. States */
 #button-container button:hover {
     background-color: #d0d0d0;


### PR DESCRIPTION
Not all repos make use of the `stale` label, and it can have any colour.

So we replace the hard-coded `Stale` field in the status bar with one that only appears when an issue with a `stale` label is found, and then use the colour it specifies.